### PR TITLE
Dictionary and ISL Bible  rerun

### DIFF
--- a/dataprep/isl/duration_calculation.py
+++ b/dataprep/isl/duration_calculation.py
@@ -1,0 +1,52 @@
+import os
+import json
+import argparse
+from pathlib import Path
+
+def find_json_files(directories):
+    """Recursively find all JSON files in the given directories."""
+    json_files = []
+    for directory in directories:
+        for root, _, files in os.walk(directory):
+            for file in files:
+                if file.endswith('.json'):
+                    json_files.append(os.path.join(root, file))
+    return json_files
+
+def get_total_duration(json_files):
+    """Sum the duration field from all JSON files."""
+    total_seconds = 0
+    for file in json_files:
+        try:
+            with open(file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                duration = data.get('duration')
+                duration = float(duration.replace(" seconds", ""))
+                if isinstance(duration, (int, float)):
+                    total_seconds += duration
+        except Exception as e:
+            print(f"Error reading {file}: {e}")
+    return total_seconds
+
+def format_duration(seconds):
+    """Convert total seconds into hours, minutes, and seconds."""
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    secs = seconds % 60
+    return int(hours), int(minutes), int(secs)
+
+def main():
+    parser = argparse.ArgumentParser(description='Calculate total duration from JSON files.')
+    parser.add_argument('directories', nargs='+', help='List of directories to search')
+    args = parser.parse_args()
+    print(f"{args.directories=}")
+
+    json_files = find_json_files(args.directories)
+    # print(f'{json_files=}')
+    total_seconds = get_total_duration(json_files)
+    print(f"{total_seconds=}")
+    h, m, s = format_duration(total_seconds)
+    print(f"Total duration: {h} hours, {m} minutes, {s} seconds")
+
+if __name__ == '__main__':
+    main()

--- a/dataprep/isl/duration_calculation.py
+++ b/dataprep/isl/duration_calculation.py
@@ -1,17 +1,6 @@
-import os
 import json
 import argparse
 from pathlib import Path
-
-def find_json_files(directories):
-    """Recursively find all JSON files in the given directories."""
-    json_files = []
-    for directory in directories:
-        for root, _, files in os.walk(directory):
-            for file in files:
-                if file.endswith('.json'):
-                    json_files.append(os.path.join(root, file))
-    return json_files
 
 def get_total_duration(json_files):
     """Sum the duration field from all JSON files."""
@@ -41,8 +30,11 @@ def main():
     args = parser.parse_args()
     print(f"{args.directories=}")
 
-    json_files = find_json_files(args.directories)
-    # print(f'{json_files=}')
+    json_files = [
+        json_file 
+        for directory in args.directories 
+     ]
+    print(f'Total number of videos : {len(json_files)}')
     total_seconds = get_total_duration(json_files)
     print(f"{total_seconds=}")
     h, m, s = format_duration(total_seconds)

--- a/dataprep/isl/duration_calculation.py
+++ b/dataprep/isl/duration_calculation.py
@@ -32,7 +32,8 @@ def main():
 
     json_files = [
         json_file 
-        for directory in args.directories 
+        for directory in args.directories
+        for json_file in Path(directory).rglob("*.json") 
      ]
     print(f'Total number of videos : {len(json_files)}')
     total_seconds = get_total_duration(json_files)

--- a/dataprep/isl/dwpose_processing.py
+++ b/dataprep/isl/dwpose_processing.py
@@ -19,7 +19,20 @@ if local_folder not in sys.path:
 from annotator.dwpose import util
 from annotator.dwpose import DWposeDetector
 from annotator.dwpose.wholebody import Wholebody
-pose_estimation = Wholebody()
+ption = Wholebody()
+
+def pose_estimate_v3(image):
+  H, W, C = oriImg.shape
+  with torch.no_grad():
+      candidate, subset = pose_estimation(oriImg)
+      nums, keys, locs = candidate.shape
+      candidate[..., 0] /= float(W)
+      candidate[..., 1] /= float(H)
+      un_visible = subset<0.3
+      candidate[un_visible] = -1
+
+      return candidate, subset
+
 
 
 def draw_pose(pose, H, W, hands_scores):
@@ -265,6 +278,7 @@ def generate_pose_files_v2(id):
       # fourcc_code = cv2.VideoWriter_fourcc(*fourcc)  # Codec (e.g., 'mp4v', 'XVID')
       # video_writer2 = cv2.VideoWriter(temp_file_pose, fourcc_code, fps, (width, height))
       poses = []
+      confidences = []
 
       while True:
           ret, frame = cap.read()
@@ -273,18 +287,30 @@ def generate_pose_files_v2(id):
           image = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
           image.flags.writeable = False
 
-          skeleton, candidate = pose_estimate_v2(image)
+          candidate, confidence = pose_estimate_v3(image)
           if len(candidate) < 1:
             candidate = [np.full(DWPOSE_LANDMARKS_NUM, np.nan, dtype=np.float64)]
           elif len(candidate > 1):
             candidate = [candidate[0]]
+
+
+          if confidence.shape[0] < 1:
+            confidence = np.full((1, DWPOSE_LANDMARKS_NUM), np.nan)
+          elif confidence.shape[0] > 1:
+            confidence = confidence[:1]
+
           assert len(candidate) == 1, f"{len(candidate)=}"
           assert len(candidate[0]) == DWPOSE_LANDMARKS_NUM, f"{len(candidate[0])=}"
           poses.append(candidate)
+
+          assert confidence.shape == (1, DWPOSE_LANDMARKS_NUM), confidence.shape
+          confidences.append(confidence)
           # Write frame to video
           # video_writer2.write(skeleton)
       # video_writer2.release()
-      np.savez_compressed(f"./{id}_pose-dwpose.npz", frames=np.array(poses, dtype=np.float64))
+      np.savez_compressed(f"./{id}_pose-dwpose.npz",
+          frames=np.array(poses, dtype=np.float64),
+          confidences = np.array(confidences, dtype=np.float64))
       cap.release()
     except Exception as exce:
         raise Exception("Error in pose video and array generation using dwpose") from exce

--- a/dataprep/isl/dwpose_processing.py
+++ b/dataprep/isl/dwpose_processing.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 
 # Load environment variables from .env
 load_dotenv()
+DWPOSE_LANDMARKS_NUM = 134
 
 local_folder = os.getenv("DWPOSE_PATH")
 if local_folder not in sys.path:
@@ -275,11 +276,11 @@ def generate_pose_files_v2(id):
 
           skeleton, candidate = pose_estimate_v2(image)
           if len(candidate) < 1:
-            candidate = [np.full(134, np.nan, dtype=np.float64)]
+            candidate = [np.full(DWPOSE_LANDMARKS_NUM, np.nan, dtype=np.float64)]
           elif len(candidate > 1):
             candidate = [candidate[0]]
           assert len(candidate) == 1, f"{len(candidate)=}"
-          assert len(candidate[0]) == 134, f"{len(candidate[0])=}"
+          assert len(candidate[0]) == DWPOSE_LANDMARKS_NUM, f"{len(candidate[0])=}"
           poses.append(candidate)
           # Write frame to video
           video_writer2.write(skeleton)

--- a/dataprep/isl/dwpose_processing.py
+++ b/dataprep/isl/dwpose_processing.py
@@ -252,19 +252,18 @@ def generate_mask_and_pose_video_files(id):
 
 def generate_pose_files_v2(id):
     try:
-      temp_file_pose =f"./{id}_pose-animation.mp4"
+      # temp_file_pose =f"./{id}_pose-animation.mp4"
 
       cap = cv2.VideoCapture(f"./{id}.mp4")
-      width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-      height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-      fps = int(cap.get(cv2.CAP_PROP_FPS))
+      # width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+      # height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+      # fps = int(cap.get(cv2.CAP_PROP_FPS))
       cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
 
-      # print(f"about to trim! Width: {width}, Height: {height}, FPS: {fps}")
 
-      fourcc="mp4v"
-      fourcc_code = cv2.VideoWriter_fourcc(*fourcc)  # Codec (e.g., 'mp4v', 'XVID')
-      video_writer2 = cv2.VideoWriter(temp_file_pose, fourcc_code, fps, (width, height))
+      # fourcc="mp4v"
+      # fourcc_code = cv2.VideoWriter_fourcc(*fourcc)  # Codec (e.g., 'mp4v', 'XVID')
+      # video_writer2 = cv2.VideoWriter(temp_file_pose, fourcc_code, fps, (width, height))
       poses = []
 
       while True:
@@ -283,8 +282,8 @@ def generate_pose_files_v2(id):
           assert len(candidate[0]) == DWPOSE_LANDMARKS_NUM, f"{len(candidate[0])=}"
           poses.append(candidate)
           # Write frame to video
-          video_writer2.write(skeleton)
-      video_writer2.release()
+          # video_writer2.write(skeleton)
+      # video_writer2.release()
       np.savez_compressed(f"./{id}_pose-dwpose.npz", frames=np.array(poses, dtype=np.float64))
       cap.release()
     except Exception as exce:

--- a/dataprep/isl/dwpose_processing.py
+++ b/dataprep/isl/dwpose_processing.py
@@ -274,12 +274,17 @@ def generate_pose_files_v2(id):
           image.flags.writeable = False
 
           skeleton, candidate = pose_estimate_v2(image)
-
+          if len(candidate) < 1:
+            candidate = [np.full(134, np.nan, dtype=np.float64)]
+          elif len(candidate > 1):
+            candidate = [candidate[0]]
+          assert len(candidate) == 1, f"{len(candidate)=}"
+          assert len(candidate[0]) == 134, f"{len(candidate[0])=}"
           poses.append(candidate)
           # Write frame to video
           video_writer2.write(skeleton)
       video_writer2.release()
-      np.savez_compressed(f"./{id}_pose-dwpose.npz", frames=np.array(poses, dtype=object))
+      np.savez_compressed(f"./{id}_pose-dwpose.npz", frames=np.array(poses, dtype=np.float64))
       cap.release()
     except Exception as exce:
         raise Exception("Error in pose video and array generation using dwpose") from exce

--- a/dataprep/isl/edit_data_files.py
+++ b/dataprep/isl/edit_data_files.py
@@ -7,6 +7,8 @@ import numpy as np
 logging.basicConfig(filename='logs/app.log', level=logging.INFO,
 					format='%(asctime)s - %(levelname)s - %(message)s')
 
+DWPOSE_LANDMARKS_NUM = 134
+
 def json_correction(filename):
 	orig_data = {}
 	with open(filename, 'r', encoding='utf-8') as fp:
@@ -21,18 +23,18 @@ def npz_correction(filename):
 	new_array = []
 	for item in old_obj['frames']:
 		if len(item) < 1:
-			item = [np.full(134, np.nan, dtype=np.float64)]
+			item = [np.full(DWPOSE_LANDMARKS_NUM, np.nan, dtype=np.float64)]
 		elif len(item > 1):
 			item = [item[0]]
 		assert len(item) == 1, f"{len(item)=}"
-		assert len(item[0]) == 134, f"{len(item[0])=}"
+		assert len(item[0]) == DWPOSE_LANDMARKS_NUM, f"{len(item[0])=}"
 		new_array.append(item)
 	np.savez_compressed(filename, frames=np.array(new_array, dtype=np.float64))
 
 def npz_test(filename):
 	new_obj = np.load(filename) # load w/o pickle
 	assert 'frames' in new_obj
-	assert len(new_obj['frames'][0][0]) == 134
+	assert len(new_obj['frames'][0][0]) == DWPOSE_LANDMARKS_NUM
 	assert len(new_obj['frames'][0][0][0]) == 2
 
 

--- a/dataprep/isl/edit_data_files.py
+++ b/dataprep/isl/edit_data_files.py
@@ -1,0 +1,61 @@
+import json
+import logging
+import argparse
+from pathlib import Path
+import numpy as np
+
+logging.basicConfig(filename='logs/app.log', level=logging.INFO,
+					format='%(asctime)s - %(levelname)s - %(message)s')
+
+def json_correction(filename):
+	orig_data = {}
+	with open(filename, 'r', encoding='utf-8') as fp:
+		orig_data = json.load(fp)
+	orig_data['transcripts'][0]['language']['BCP-47'] = "en-US"
+	orig_data['glosses'][0]['language']['BCP-47'] = "en-US"
+	with open(filename, 'w', encoding='utf-8') as fp:
+		json.dump(orig_data, fp, indent=4)
+
+def npz_correction(filename):
+	old_obj = np.load(filename, allow_pickle=True)
+	new_array = []
+	for item in old_obj['frames']:
+		if len(item) < 1:
+			item = [np.full(134, np.nan, dtype=np.float64)]
+		elif len(item > 1):
+			item = [item[0]]
+		assert len(item) == 1, f"{len(item)=}"
+		assert len(item[0]) == 134, f"{len(item[0])=}"
+		new_array.append(item)
+	np.savez_compressed(filename, frames=np.array(new_array, dtype=np.float64))
+
+def npz_test(filename):
+	new_obj = np.load(filename) # load w/o pickle
+	assert 'frames' in new_obj
+	assert len(new_obj['frames'][0][0]) == 134
+	assert len(new_obj['frames'][0][0][0]) == 2
+
+
+def main():
+	parser = argparse.ArgumentParser(description='Calculate total duration from JSON files.')
+	parser.add_argument('directories', nargs='+', help='List of directories to search')
+	args = parser.parse_args()
+
+	candidate_files = [
+		file 
+		for directory in args.directories 
+		# for file in Path(directory).rglob("*.json") 
+		for file in Path(directory).rglob("*.npz")
+	]
+
+	for file in candidate_files:
+		try:
+			# json_correction(file) 
+			# npz_correction(file)
+			npz_test(file)
+			logging.info(f"Edited {file}")
+		except Exception as e:
+			logging.exception(f"{file} Errored out!!!!")
+
+if __name__ == '__main__':
+	main()

--- a/dataprep/isl/ffmpeg_downsample.py
+++ b/dataprep/isl/ffmpeg_downsample.py
@@ -8,7 +8,7 @@ def downsample_video(video_stream):
     process = (
         ffmpeg
         .input('pipe:', format='mp4')  # Ensure input format is correct
-        .output('pipe:', format='mpegts', vf='scale=640:-2', vcodec='libx264', preset='ultrafast', crf=28)
+        .output('pipe:', format='mpegts', vf='scale=1080:-2', vcodec='libx264', preset='ultrafast', crf=28)
         .run_async(pipe_stdin=True, pipe_stdout=True, pipe_stderr=True, overwrite_output=True)
     )
     out, _ = process.communicate(input=video_stream.read())
@@ -40,7 +40,7 @@ def downsample_video_ondisk(input_path, output_path):
             .output(
                 output_path,
                 format='mp4',                   # output as MP4
-                vf='scale=640:-2',              # resize width to 640, preserve aspect ratio
+                vf='scale=1080:-2',              # resize width to 1080, preserve aspect ratio
                 vcodec='libx264',
                 preset='ultrafast',
                 crf=28

--- a/dataprep/isl/isl_dict_processing.py
+++ b/dataprep/isl/isl_dict_processing.py
@@ -150,34 +150,6 @@ def get_cloud_files(s3_conn):
 	return original_files
 
 
-def main():
-	s3_conn = S3_connection()
-
-	original_files = get_cloud_files(s3_conn)
-
-
-	# # Run with ThreadPoolExecutor
-	# with ThreadPoolExecutor(max_workers=10) as executor:
-	#     executor.map(process_video, original_files[1296:], range(1296, len(original_files), s3_conn))
-
-	for i in range(0,10):
-		file_key = original_files[i]
-		# if i < 650:
-		#   continue
-		print(i)
-		process_video(file_key, i, s3_conn)
-
-def main_v2():
-	if len(sys.argv) != 4:
-		print("Usage: python process_video_script.py <path> <id>")
-		sys.exit(1)
-
-	video_id = int(sys.argv[1])
-	video_path = sys.argv[2]
-	output_path = sys.argv[3]
-
-	process_video_v2(video_id, video_path, output_path)
-
 def main_seqential(input_list, output_path):
 	inp_args = []
 	with open(input_list, 'r', encoding='utf-8') as fp:
@@ -186,13 +158,11 @@ def main_seqential(input_list, output_path):
 						for line in inp_lines]
 
 	now = datetime.datetime.now()
-	success_log = open("logs/success.log", "w", encoding='utf-8')
-	success_log.write(f"-------------start{now:%Y-%m-%d %H:%M:%S}----------\n")
-	success_log.close()
+	with open("logs/success.log", "w", encoding='utf-8') as success_log:
+		success_log.write(f"-------------start {now:%Y-%m-%d %H:%M:%S}----------\n")
 
-	fail_log = open("logs/fail.log", "w", encoding='utf-8')
-	fail_log.write(f"-------------start{now:%Y-%m-%d %H:%M:%S}----------\n")
-	fail_log.close()
+	with open("logs/fail.log", "w", encoding='utf-8') as fail_log:
+		fail_log.write(f"-------------start {now:%Y-%m-%d %H:%M:%S}----------\n")
 
 	for args in inp_args:
 		try:
@@ -204,9 +174,11 @@ def main_seqential(input_list, output_path):
 			with open("logs/fail.log", "a", encoding='utf-8') as fail_log:
 				fail_log.write(f"{args[0]}\t{args[1]}")
 
-if __name__ == '__main__':
-	# main()
+	with open("logs/success.log", "a", encoding='utf-8') as success_log:
+		now = datetime.datetime.now()
+		success_log.write(f"-------------end {now:%Y-%m-%d %H:%M:%S}----------\n")
 
-	# main_v2()
+
+if __name__ == '__main__':
 
 	main_seqential("dict_retry.txt", "../../../Dictionary_processed2/")

--- a/dataprep/isl/isl_dict_processing.py
+++ b/dataprep/isl/isl_dict_processing.py
@@ -1,18 +1,117 @@
 import json
 import os
 import io
+import glob
+import sys
+from pathlib import Path
+import shutil
 from dotenv import load_dotenv
 from concurrent.futures import ThreadPoolExecutor
+import ffmpeg
+import datetime
+import logging
 
-from s3_connect import S3_connection
+# from s3_connect import S3_connection
 from ffmpeg_downsample import downsample_video
+from pose_format_util import video2poseformat
 from mediapipe_trim import trim_off_storyboard
-from dwpose_processing import generate_mask_and_pose_video_streams
+from dwpose_processing import generate_pose_files_v2
 
 
 # Load environment variables from .env
 load_dotenv()
 bucket_name = os.getenv("BUCKET_NAME")
+
+logging.basicConfig(filename='logs/app.log', level=logging.ERROR,
+                    format='%(asctime)s - %(levelname)s - %(message)s')
+
+
+def process_video_v2(id, input_path, output_path):
+	"""Pipeline:
+		--> use already downsampled and downloaded videos
+		--> process: pose estimation, metadata etc
+		--> keep in a local path for tar building later"""
+	main_path = Path(output_path) / f"{id}.mp4"
+	try:
+		# video_stream = s3_conn.download_video(bucket_name, input_key)
+
+		# downsample_video_ondisk(f"{id}_large.mp4", f"{id}.mp4")
+		shutil.copy(input_path, f"./{id}.mp4") 
+		
+
+		trimmed_stream = trim_off_storyboard(None, id)
+		if not trimmed_stream:
+			raise Exception("Processing with mediapipe failed")
+		video2poseformat(id) #  .pose format using mediapipe
+		generate_pose_files_v2(id) # mp4, and npz usging dwpose
+
+		shutil.move(f"{id}.mp4", main_path)
+		shutil.move(f"{id}_pose-animation.mp4", f"{output_path}/{id}.pose-animation.mp4")
+		shutil.move(f"{id}_pose-mediapipe.pose", f"{output_path}/{id}.pose-mediapipe.pose")
+		shutil.move(f"{id}_pose-dwpose.npz", f"{output_path}/{id}.pose-dwpose.npz")
+
+		text = read_old_json(input_path.replace(".mp4", ".json"))
+
+		probe = ffmpeg.probe(main_path)
+		duration = float(probe['format']['duration'])
+
+		signer = "xxx"
+
+		metadata = {"filename": f"{id}.mp4",
+					"pose": {
+						"animation": f"{id}.pose-animation.mp4",
+						"mediapipe": f"{id}.pose-mediapipe.pose",
+						"dwpose": f"{id}.pose-dwpose.npz"
+					},
+					# "source": "https://www.youtube.com/@islv-holybible",
+					"license": "CC-BY-SA",
+					"language": {
+						"name": "Indian Sign Language",
+						"ISO639-3": "ins",
+						"BCP-47": "ins-IN"
+					},
+					# "bible-ref": ref,
+					# "biblenlp-vref": vref,
+					"duration": f"{duration} seconds",
+					"signer": signer,
+					"transcripts": [{
+								"text": text,
+								"language": {
+									"name": "English",
+									"ISO639-3": "eng",
+									"BCP-47": "eng-US"
+								},
+								"source": "Berean Standard Bible",
+							}],
+					"glosses": [{
+								"text": [(0,duration,text)],
+								"language": {
+									"name": "English",
+									"ISO639-3": "eng",
+									"BCP-47": "eng"
+								}
+
+								}]
+					}
+		with open(f"{output_path}/{id}.json", "w") as f:
+			json.dump(metadata, f, indent=4)
+		print(f'Processed {id}!!!!!!!!!!!!!!!!!!!!')
+	finally:
+		clear_space(f"{id}_large.mp4")
+		clear_space(f"{id}.mp4")
+		clear_space(f"{id}_pose-animation.mp4")
+		clear_space(f"{id}_pose-dwpose.npz")
+		clear_space(f"{id}_pose-mediapipe.pose")
+
+def clear_space(file_path):
+	if os.path.exists(file_path):
+		os.remove(file_path)
+
+def read_old_json(file_name):
+	metadata = {}
+	with open(file_name, 'r', encoding="utf-8") as fp:
+		metadata = json.load(fp)
+	return metadata['text-transcript']
 
 def process_video(input_key, id, s3_conn):
 	"""Full pipeline: download -> downsample -> upload"""
@@ -68,6 +167,46 @@ def main():
 		print(i)
 		process_video(file_key, i, s3_conn)
 
+def main_v2():
+	if len(sys.argv) != 4:
+		print("Usage: python process_video_script.py <path> <id>")
+		sys.exit(1)
+
+	video_id = int(sys.argv[1])
+	video_path = sys.argv[2]
+	output_path = sys.argv[3]
+
+	process_video_v2(video_id, video_path, output_path)
+
+def main_seqential(input_list, output_path):
+	inp_args = []
+	with open(input_list, 'r', encoding='utf-8') as fp:
+		inp_lines = fp.readlines()
+		inp_args = [line.split('\t')
+						for line in inp_lines]
+
+	now = datetime.datetime.now()
+	success_log = open("logs/success.log", "w", encoding='utf-8')
+	success_log.write(f"-------------start{now:%Y-%m-%d %H:%M:%S}----------\n")
+	success_log.close()
+
+	fail_log = open("logs/fail.log", "w", encoding='utf-8')
+	fail_log.write(f"-------------start{now:%Y-%m-%d %H:%M:%S}----------\n")
+	fail_log.close()
+
+	for args in inp_args:
+		try:
+			process_video_v2(args[0].strip(), args[1].strip(), output_path)
+			with open("logs/success.log", "a", encoding='utf-8') as success_log:
+				success_log.write(f"{args[0]}\t{args[1]}")
+		except Exception as exce:
+			logging.exception(f"{id} Errored out!!!")
+			with open("logs/fail.log", "a", encoding='utf-8') as fail_log:
+				fail_log.write(f"{args[0]}\t{args[1]}")
 
 if __name__ == '__main__':
-	main()
+	# main()
+
+	# main_v2()
+
+	main_seqential("dict_retry.txt", "../../../Dictionary_processed2/")

--- a/dataprep/isl/isl_dict_processing.py
+++ b/dataprep/isl/isl_dict_processing.py
@@ -79,7 +79,7 @@ def process_video_v2(id, input_path, output_path):
 								"language": {
 									"name": "English",
 									"ISO639-3": "eng",
-									"BCP-47": "eng-US"
+									"BCP-47": "en-US"
 								},
 								"source": "Berean Standard Bible",
 							}],
@@ -88,7 +88,7 @@ def process_video_v2(id, input_path, output_path):
 								"language": {
 									"name": "English",
 									"ISO639-3": "eng",
-									"BCP-47": "eng"
+									"BCP-47": "en"
 								}
 
 								}]

--- a/dataprep/isl/isl_dict_processing.py
+++ b/dataprep/isl/isl_dict_processing.py
@@ -46,7 +46,7 @@ def process_video_v2(id, input_path, output_path):
 		generate_pose_files_v2(id) # mp4, and npz usging dwpose
 
 		shutil.move(f"{id}.mp4", main_path)
-		shutil.move(f"{id}_pose-animation.mp4", f"{output_path}/{id}.pose-animation.mp4")
+		# shutil.move(f"{id}_pose-animation.mp4", f"{output_path}/{id}.pose-animation.mp4")
 		shutil.move(f"{id}_pose-mediapipe.pose", f"{output_path}/{id}.pose-mediapipe.pose")
 		shutil.move(f"{id}_pose-dwpose.npz", f"{output_path}/{id}.pose-dwpose.npz")
 
@@ -59,7 +59,7 @@ def process_video_v2(id, input_path, output_path):
 
 		metadata = {"filename": f"{id}.mp4",
 					"pose": {
-						"animation": f"{id}.pose-animation.mp4",
+						# "animation": f"{id}.pose-animation.mp4",
 						"mediapipe": f"{id}.pose-mediapipe.pose",
 						"dwpose": f"{id}.pose-dwpose.npz"
 					},

--- a/dataprep/isl/isl_gospel_processing.py
+++ b/dataprep/isl/isl_gospel_processing.py
@@ -82,7 +82,7 @@ def process_video(id, remote_path, nxt_cld_conn, output_path):
 								"language": {
 									"name": "English",
 									"ISO639-3": "eng",
-									"BCP-47": "eng-US"
+									"BCP-47": "en-US"
 								},
 								"source": "Berean Standard Bible",
 							}],
@@ -91,7 +91,7 @@ def process_video(id, remote_path, nxt_cld_conn, output_path):
 								"language": {
 									"name": "English",
 									"ISO639-3": "eng",
-									"BCP-47": "eng"
+									"BCP-47": "en"
 								}
 
 								}]

--- a/dataprep/isl/isl_gospel_processing.py
+++ b/dataprep/isl/isl_gospel_processing.py
@@ -111,75 +111,6 @@ def clear_space(file_path):
 		os.remove(file_path)
 
 
-def process_video_onmount(id, orig_path, processed_path): 
-	'''NOT updated as per the changes in process_video'''
-
-	downsample_video_ondisk(orig_path, f"{id}.mp4")
-
-	trimmed_stream = trim_off_storyboard(None, id)
-	try:
-		if not trimmed_stream:
-			raise Exception("Processing with mediapipe failed")
-		generate_mask_and_pose_video_files(id)
-
-		output_path = f"{processed_path}/{id}.mp4"
-		shutil.move(f"{id}.mp4", output_path)
-		shutil.move(f"{id}_pose.mp4", f"{output_path}/{id}.pose.mp4")
-		shutil.move(f"{id}_mask.mp4", f"{output_path}/{id}.mask.mp4")
-
-		parts = orig_path.split("/")
-		ref = f"{parts[-3]} {parts[-2].replace("Ch ", "")}"
-		verse = parts[-1].split(".")[0].split(" ")[1]
-		verse_parts = "-".join(verse.split("-")[:-1])
-		ref = f"{ref}:{verse_parts}"
-
-
-		parts = remote_path.split("/")
-		ref = f"{parts[0]} {parts[1].replace("Ch ", "")} "
-		verse = parts[-1].split(".")[0].split(" ")[-1]
-		verse = re.sub(junk_pattern_in_filename, verse, "")
-		ref = ref+verse
-
-		metadata = {"filename": f"{id}.mp4",
-					"pose":f"{id}.pose.mp4", 
-					"mask":f"{id}.mask.mp4",
-					"source": f"{ref} of https://www.youtube.com/@islv-holybible",
-					"license": "CC-BY-SA",
-					"bible-ref": ref,
-					"transcripts": [{
-								"text": get_verses(ref),
-								"language": "English",
-								"ISO 639-1": "en"
-							}],
-					"glosses": [{
-								"text": [(0,0,"nil")],
-								"language": "English",
-								"ISO 639-1": "en"
-
-								}]
-					}
-		with open(f"{id}.json", "w") as f:
-			json.dump(metadata, f, indent=4, sort_keys=True)
-		shutil.move(f"{id}.json", f"{output_path}/{id}.json")
-		print(f'processed {id}!!!!!!!!!!!!!!!!!!!!')
-	except Exception as exce:
-		# print(exce)
-		raise exce
-
-
-
-def main():
-	if len(sys.argv) != 4:
-		print("Usage: python process_video_script.py <path> <id>")
-		sys.exit(1)
-
-	video_id = int(sys.argv[1])
-	video_path = sys.argv[2]
-
-	# nxt_cld_conn = NextCloud_connection()
-	output_path = "/mnt/share/processed_path"
-	process_video_onmount(video_id, video_path, output_path)
-
 def main_nxtcld():
 	if len(sys.argv) != 4:
 		print("Usage: python process_video_script.py <path> <id>")
@@ -190,7 +121,7 @@ def main_nxtcld():
 	output_path = sys.argv[3]
 
 	nxt_cld_conn = None
-	nxt_cld_conn = NextCloud_connection()
+	# nxt_cld_conn = NextCloud_connection()
 	process_video(video_id, video_path, nxt_cld_conn, output_path)
 
 

--- a/dataprep/isl/isl_gospel_processing.py
+++ b/dataprep/isl/isl_gospel_processing.py
@@ -35,7 +35,7 @@ def process_video(id, remote_path, nxt_cld_conn, output_path):
 		generate_pose_files_v2(id) # mp4, and npz usging dwpose
 
 		# shutil.move(f"{id}.mp4", output_path)
-		shutil.move(f"{id}_pose-animation.mp4", f"{output_path}/{id}.pose-animation.mp4")
+		# shutil.move(f"{id}_pose-animation.mp4", f"{output_path}/{id}.pose-animation.mp4")
 		shutil.move(f"{id}_pose-mediapipe.pose", f"{output_path}/{id}.pose-mediapipe.pose")
 		shutil.move(f"{id}_pose-dwpose.npz", f"{output_path}/{id}.pose-dwpose.npz")
 
@@ -62,7 +62,7 @@ def process_video(id, remote_path, nxt_cld_conn, output_path):
 
 		metadata = {"filename": f"{id}.mp4",
 					"pose": {
-						"animation": f"{id}.pose-animation.mp4",
+						# "animation": f"{id}.pose-animation.mp4",
 						"mediapipe": f"{id}.pose-mediapipe.pose",
 						"dwpose": f"{id}.pose-dwpose.npz"
 					},

--- a/dataprep/isl/mediapipe_trim.py
+++ b/dataprep/isl/mediapipe_trim.py
@@ -36,7 +36,9 @@ class VideoTrimmer:
             # Process frame with Holistic model
             results = self.holistic.process(rgb_frame)
 
-            # person_detected = results.pose_landmarks is not None
+            person_detected = results.pose_landmarks is not None
+            if not person_detected or not results.pose_landmarks.landmark[12].x:
+              continue
             # face_detected = results.face_landmarks is not None
             if results.right_hand_landmarks:
               if right_hand_pos is None:
@@ -74,9 +76,9 @@ class VideoTrimmer:
         # print(f"Trim frame found at frame {trim_frame}.")
         output_stream = io.BytesIO()
         if trim_frame < 10:
-          with open(f"{id}.mp4", "rb") as f:
+          print(f"Trim frame {trim_frame} < 10. Hence keeping the video as such")
+          with open(f"{self.thread_id}.mp4", "rb") as f:
             output_stream.write(f.read())
-          # os.remove(f"./{self.thread_id}.mp4")
           output_stream.seek(0)
           return output_stream
 


### PR DESCRIPTION
Rebuild the ISL dictionary data in the new required format.
Contain 3077 glosses.

Differences between ISL dictionary dataset from the Bible dataset:
- source field not included
- biblenlp-vref and bible-ref not included
- gloss added with 0 to full duation marked as a single gloss

:warning: signer id not added yet.